### PR TITLE
Use single quotes in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
       { from: 'manifest.konnector' },
       { from: 'package.json' },
       { from: 'README.md' },
-      { from: "assets" },
+      { from: 'assets' },
       { from: 'LICENSE' }
     ])
   ]


### PR DESCRIPTION
Some tool changed it automatically so I assume this is the expected format.