### PR TITLE
feat: Childminder account support

### DIFF
--- a/src/childminder.js
+++ b/src/childminder.js
@@ -1,0 +1,107 @@
+const { log, normalizeFilename } = require('cozy-konnector-libs')
+const groupBy = require('lodash.groupby')
+const map = require('lodash.map')
+
+const payslip = require('./payslip')
+const period = require('./period')
+const { baseUrl, request } = require('./request')
+
+const listUrl = baseUrl + '/attesemploisala.jsp'
+const rowsPerPage = 10
+
+module.exports = {
+  fetchPayslips
+}
+
+function fetchPayslips({ periodRange, folderPath }) {
+  return fetchPagesCount(periodRange)
+    .then(function(pagesCount) {
+      log('info', `Found ${pagesCount} payslips page(s)`)
+
+      let payslipsPromise = Promise.resolve([])
+
+      for (let pageNumber = 1; pageNumber <= pagesCount; pageNumber++) {
+        payslipsPromise = payslipsPromise.then(function(payslips) {
+          return requestPayslipsPage(periodRange, pageNumber).then($ => {
+            const newPayslips = parsePayslipsPage($, pageNumber)
+            return payslips.concat(newPayslips)
+          })
+        })
+      }
+
+      return payslipsPromise
+    })
+    .then(payslips =>
+      fetchPayslipFiles(groupBy(payslips, 'employer'), folderPath)
+    )
+}
+
+function fetchPagesCount(periodRange) {
+  return requestPayslipsPage(periodRange).then(parsePagesCount)
+}
+
+function parsePagesCount($) {
+  return parseInt(
+    $(`form[name="etat"]`)
+      .prev('div')
+      .find('a:last-child')
+      .text()
+  )
+}
+
+function requestPayslipsPage(periodRange, pageNumber) {
+  pageNumber = pageNumber || 1
+  const offset = (pageNumber - 1) * rowsPerPage
+
+  return request({
+    method: 'POST',
+    uri: listUrl,
+    form: {
+      typeActivite: 'A',
+      debutAnneePeriode: periodRange.start.year,
+      debutMoisPeriode: periodRange.start.month,
+      finAnneePeriode: periodRange.end.year,
+      finMoisPeriode: periodRange.end.month,
+      psdoSirt: '', // All employers
+      nbStart: offset.toString(),
+      order: 'periode',
+      choixDate: 'emploi'
+    }
+  })
+}
+
+function parsePayslipsPage($, pageNumber) {
+  log('info', `Parsing payslips page ${pageNumber}...`)
+  return Array.from(
+    $('table tr:has(>.tableau-cellule1,>.tableau-cellule2)')
+  ).map(tr => parsePayslipRow($(tr)))
+}
+
+function parsePayslipRow($tr) {
+  // For some reason, employer names are uppercase.
+  const employer = $tr.find('td:nth-child(2)').text()
+  const [year, month] = period.parse($tr.find('td:nth-child(3)').text())
+  const amount = parseFloat($tr.find('td:nth-child(4)').text())
+  const href = $tr
+    .find('td:nth-child(1) a[alt="Bulletin de salaire"]')
+    .attr('href')
+  const ref = href && href.split('=')[1]
+
+  return {
+    employer,
+    period: `${year}-${month}`,
+    amount,
+    ref
+  }
+}
+
+function fetchPayslipFiles(payslipsByEmployer, folderPath) {
+  return Promise.all(
+    map(payslipsByEmployer, (payslips, employer) => {
+      payslip.fetch({
+        payslips,
+        folderPath: `${folderPath}/${normalizeFilename(employer)}`
+      })
+    })
+  )
+}

--- a/src/employer.js
+++ b/src/employer.js
@@ -13,11 +13,16 @@ const listUrl = baseUrl + '/ajaxlistebs.jsp'
 const downloadUrl = baseUrl + '/paje_bulletinsalaire.pdf'
 
 module.exports = {
-  fetchPayslips,
-  fetchPayslipFiles
+  fetchPayslips
 }
 
-function fetchPayslips() {
+function fetchPayslips(folderPath) {
+  return fetchPayslipsMetadata().then(payslipsByEmployee =>
+    fetchPayslipFiles(payslipsByEmployee, folderPath)
+  )
+}
+
+function fetchPayslipsMetadata() {
   const today = new Date()
   const startYear = '2004' // Pajemploi exists since 2004
   const startMonth = '01'

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ process.env.SENTRY_DSN =
 const { BaseKonnector } = require('cozy-konnector-libs')
 
 const { authenticate } = require('./auth')
+const childminder = require('./childminder')
 const employer = require('./employer')
 const period = require('./period')
 
@@ -14,7 +15,11 @@ module.exports = new BaseKonnector(function fetch(fields) {
   const today = new Date()
   const periodRange = period.range(today)
 
-  return authenticate(fields.login, fields.password).then(() =>
-    employer.fetchPayslips({ periodRange, folderPath: fields.folderPath })
-  )
+  return authenticate(fields.login, fields.password)
+    .then(() =>
+      employer.fetchPayslips({ periodRange, folderPath: fields.folderPath })
+    )
+    .then(() =>
+      childminder.fetchPayslips({ periodRange, folderPath: fields.folderPath })
+    )
 })

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,10 @@ process.env.SENTRY_DSN =
 const { BaseKonnector } = require('cozy-konnector-libs')
 
 const { authenticate } = require('./auth')
-const { fetchPayslips, fetchPayslipFiles } = require('./employer')
+const employer = require('./employer')
 
 module.exports = new BaseKonnector(function fetch(fields) {
-  return authenticate(fields.login, fields.password)
-    .then(fetchPayslips)
-    .then(payslipsByEmployee =>
-      fetchPayslipFiles(payslipsByEmployee, fields.folderPath)
-    )
+  return authenticate(fields.login, fields.password).then(() =>
+    employer.fetchPayslips(fields.folderPath)
+  )
 })

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,13 @@ const { BaseKonnector } = require('cozy-konnector-libs')
 
 const { authenticate } = require('./auth')
 const employer = require('./employer')
+const period = require('./period')
 
 module.exports = new BaseKonnector(function fetch(fields) {
+  const today = new Date()
+  const periodRange = period.range(today)
+
   return authenticate(fields.login, fields.password).then(() =>
-    employer.fetchPayslips(fields.folderPath)
+    employer.fetchPayslips({ periodRange, folderPath: fields.folderPath })
   )
 })

--- a/src/payslip.js
+++ b/src/payslip.js
@@ -1,0 +1,30 @@
+const { mkdirp, saveFiles } = require('cozy-konnector-libs')
+
+const { baseUrl } = require('./request')
+
+const downloadUrl = baseUrl + '/paje_bulletinsalaire.pdf'
+
+module.exports = {
+  downloadUrl,
+  fetch,
+  fileEntry
+}
+
+function fetch({ payslips, folderPath }) {
+  const files = payslips.map(fileEntry)
+  return mkdirp(folderPath).then(() => saveFiles(files, folderPath))
+}
+
+function fileEntry({ period, ref, norng }) {
+  return {
+    fileurl: downloadUrl,
+    filename: `${period}.pdf`,
+    requestOptions: {
+      method: 'POST',
+      formData: {
+        ref,
+        norng
+      }
+    }
+  }
+}

--- a/src/payslip.js
+++ b/src/payslip.js
@@ -19,12 +19,14 @@ function fileEntry({ period, ref, norng }) {
   return {
     fileurl: downloadUrl,
     filename: `${period}.pdf`,
-    requestOptions: {
-      method: 'POST',
-      formData: {
-        ref,
-        norng
-      }
-    }
+    requestOptions: requestOptions({ ref, norng })
+  }
+}
+
+function requestOptions({ ref, norng }) {
+  if (norng) {
+    return { method: 'POST', formData: { ref, norng } }
+  } else {
+    return { qs: { ref } }
   }
 }

--- a/src/payslip.spec.js
+++ b/src/payslip.spec.js
@@ -1,0 +1,25 @@
+const payslip = require('./payslip')
+
+describe('payslip', () => {
+  describe('fileEntry', () => {
+    it('uses POST request for an employer', () => {
+      expect(
+        payslip.fileEntry({
+          period: '2018-01',
+          ref: '123',
+          norng: '456'
+        })
+      ).toEqual({
+        fileurl: payslip.downloadUrl,
+        filename: '2018-01.pdf',
+        requestOptions: {
+          method: 'POST',
+          formData: {
+            ref: '123',
+            norng: '456'
+          }
+        }
+      })
+    })
+  })
+})

--- a/src/period.js
+++ b/src/period.js
@@ -1,0 +1,37 @@
+const pajemploiCreation = {
+  year: '2004',
+  month: '01'
+}
+
+module.exports = {
+  pajemploiCreation,
+  parse,
+  range,
+  rangeToSentence
+}
+
+const frRegExp = /\s*(\d{2})\/(\d{4}).*/
+const isoRegExp = /\s*(\d{4})-(\d{2}).*/
+
+function parse(periodString) {
+  const frMatch = frRegExp.exec(periodString)
+  if (frMatch) return frMatch.slice(1, 3).reverse()
+  else return isoRegExp.exec(periodString).slice(1, 3)
+}
+
+function range(endDate) {
+  return {
+    start: pajemploiCreation,
+    end: {
+      year: endDate.getFullYear().toString(),
+      month: `0${endDate.getMonth() + 1}`.slice(-2)
+    }
+  }
+}
+
+function rangeToSentence(range) {
+  return (
+    `from ${range.start.month}/${range.start.year}` +
+    ` to ${range.end.month}/${range.end.year}`
+  )
+}

--- a/src/period.spec.js
+++ b/src/period.spec.js
@@ -1,0 +1,42 @@
+const period = require('./period')
+
+describe('period', () => {
+  describe('parse', () => {
+    it('returns an array representation of the french period string', () => {
+      expect(period.parse('01/2018')).toEqual(['2018', '01'])
+    })
+
+    it('works with ISO dates, which happen for unknown reason', () => {
+      expect(period.parse('2017-02-01 00:00:00.0')).toEqual(['2017', '02'])
+    })
+  })
+
+  describe('range', () => {
+    it("builds a period range from pajemploiCreation up to the given date's month & year", () => {
+      expect(period.range(new Date(2018, 2))).toEqual({
+        start: period.pajemploiCreation,
+        end: {
+          month: '03',
+          year: '2018'
+        }
+      })
+    })
+  })
+
+  describe('rangeToSentence', () => {
+    it('returns a human-friendly description of the period range', () => {
+      expect(
+        period.rangeToSentence({
+          start: {
+            year: '2010',
+            month: '02'
+          },
+          end: {
+            year: '2013',
+            month: '04'
+          }
+        })
+      ).toEqual('from 02/2010 to 04/2013')
+    })
+  })
+})


### PR DESCRIPTION
Logic that is common to both employer & childminder sides was extracted to reusable modules.

Motivation regarding the *employer* and *childminder* wording:
- the *employer* is not necessarily the parent
- the *childminder* is necessarily a childminder
- having both *employer* and *employee* makes for easy typos :)

Employer names seem to be uppercase everywhere, so I didn't try to set up some risky case conversion.

Also there was a bug on Pajemploi's side on a short time period where the same childminder could have its name written with both a space  or a `<br/>` as a separator. The bug was fixed on their side. The name parsing could definitely be more robust, but this feature was missing for quite some time so I decided to ship it anyway.